### PR TITLE
Add participation timeline to PDF reports

### DIFF
--- a/server/pdfTemplate.ts
+++ b/server/pdfTemplate.ts
@@ -4,6 +4,7 @@ export function generatePdfTemplate(data: {
   analytics: any;
   generatedAt: string;
   chartsHtml: string;
+  participationTimeline: { month: string; count: number }[];
 }) {
   const { stats, analytics, generatedAt, chartsHtml } = data;
   


### PR DESCRIPTION
## Summary
- aggregate monthly survey response counts in `fetchReportData` and expose a formatted participation timeline for downstream consumers
- render the trend chart with real participation data, including graceful handling when no timeline points are available
- thread participation timeline data through chart generation and the PDF template so exports reflect actual response trends

## Testing
- npm run lint (fails: existing lint errors unrelated to this change)
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd338f484483219f18f9b98292cdd0