### PR TITLE
Adjust survey spacing and card styling

### DIFF
--- a/src/components/survey/Question.tsx
+++ b/src/components/survey/Question.tsx
@@ -14,25 +14,25 @@ interface QuestionProps {
 
 export function Question({ question, name, value, onChange, options, required = true, hasError = false, questionNumber }: QuestionProps) {
   return (
-    <div 
+    <div
       id={`question-${name}`}
-      className={`question-card-enhanced p-6 mb-4 fade-in ${
+      className={`question-card-enhanced p-4 mb-3 fade-in ${
         hasError ? 'question-card-error border-destructive/40' : ''
       }`}
     >
       {hasError && (
-        <div className="mb-3 p-3 bg-destructive/10 border border-destructive/20 rounded-xl">
+        <div className="mb-2 p-3 bg-destructive/10 border border-destructive/20 rounded-xl">
           <p className="text-destructive text-sm font-medium flex items-center gap-2">
             <Building2 className="w-4 h-4" />
             Esta pergunta é obrigatória
           </p>
         </div>
       )}
-      
-      <div className="flex items-start gap-4 mb-4">
+
+      <div className="flex items-start gap-3 mb-3">
         <div className={`w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0 shadow-sm transition-all duration-300 ${
-          hasError 
-            ? 'bg-destructive text-white' 
+          hasError
+            ? 'bg-destructive text-white'
             : 'bg-gradient-primary text-white'
         }`}>
           {questionNumber ? (
@@ -49,12 +49,12 @@ export function Question({ question, name, value, onChange, options, required = 
           </Label>
         </div>
       </div>
-      
+
       <div className="flex justify-center">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 w-full max-w-4xl">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 w-full max-w-4xl">
           {options.map((option, index) => {
             const isSelected = value === option.value;
-            
+
             return (
               <button
                 key={option.value}
@@ -70,15 +70,15 @@ export function Question({ question, name, value, onChange, options, required = 
                 aria-pressed={isSelected}
                 aria-label={`${option.label} ${isSelected ? '(selecionado)' : ''}`}
                 className={`
-                  option-button-enhanced text-center min-h-[50px] flex items-center justify-center
+                  option-button-enhanced text-center min-h-[48px] flex items-center justify-center
                   ${isSelected ? 'option-button-selected-enhanced pulse-success' : 'option-button-unselected-enhanced'}
                 `}
                 style={{
                   animationDelay: `${index * 0.1}s`
                 }}
               >
-                <div className="flex items-center justify-center gap-3">
-                  {isSelected && <CheckCircle2 className="w-5 h-5 flex-shrink-0" />}
+                <div className="flex items-center justify-center gap-2">
+                  {isSelected && <CheckCircle2 className="w-4 h-4 flex-shrink-0" />}
                   <span className="font-medium leading-tight">{option.label}</span>
                 </div>
               </button>

--- a/src/components/survey/SelectQuestion.tsx
+++ b/src/components/survey/SelectQuestion.tsx
@@ -26,25 +26,25 @@ export function SelectQuestion({
   questionNumber 
 }: SelectQuestionProps) {
   return (
-    <div 
+    <div
       id={`question-${name}`}
-      className={`question-card-enhanced p-6 mb-4 fade-in ${
+      className={`question-card-enhanced p-4 mb-3 fade-in ${
         hasError ? 'question-card-error border-destructive/40' : ''
       }`}
     >
       {hasError && (
-        <div className="mb-3 p-3 bg-destructive/10 border border-destructive/20 rounded-xl">
+        <div className="mb-2 p-3 bg-destructive/10 border border-destructive/20 rounded-xl">
           <p className="text-destructive text-sm font-medium flex items-center gap-2">
             <Building2 className="w-4 h-4" />
             Esta pergunta é obrigatória
           </p>
         </div>
       )}
-      
-      <div className="flex items-start gap-4 mb-4">
+
+      <div className="flex items-start gap-3 mb-3">
         <div className={`w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0 shadow-sm transition-all duration-300 ${
-          hasError 
-            ? 'bg-destructive text-white' 
+          hasError
+            ? 'bg-destructive text-white'
             : 'bg-gradient-primary text-white'
         }`}>
           {questionNumber ? (
@@ -54,39 +54,39 @@ export function SelectQuestion({
           )}
         </div>
         <div className="flex-1">
-          <Label className={`text-sm md:text-base font-semibold leading-snug block mb-3 ${
+          <Label className={`text-sm md:text-base font-semibold leading-snug block mb-2 ${
             hasError ? 'text-destructive' : 'text-slate-800'
           }`}>
             {question}
           </Label>
-          
-          <div className="flex justify-center">
-            <Select value={value} onValueChange={onChange}>
-              <SelectTrigger 
-                className={`w-full max-w-lg h-12 text-base bg-white/95 backdrop-blur-sm border-2 rounded-xl transition-all duration-300 hover:shadow-md hover:scale-[1.01] focus:scale-[1.01] ${
-                  hasError 
-                    ? 'border-destructive/50 focus:border-destructive focus:ring-2 focus:ring-destructive/20' 
-                    : 'border-border focus:border-primary hover:border-primary/50 focus:ring-2 focus:ring-primary/20'
-                }`}
-              >
-                <SelectValue 
-                  placeholder={placeholder}
-                  className={`${value ? 'text-slate-800 font-medium' : 'text-muted-foreground'}`}
-                />
-              </SelectTrigger>
+
+            <div className="flex justify-center">
+              <Select value={value} onValueChange={onChange}>
+                <SelectTrigger
+                  className={`w-full max-w-lg h-11 text-base bg-white/95 backdrop-blur-sm border rounded-xl transition-all duration-200 hover:shadow-sm hover:scale-[1.01] focus:scale-[1.01] ${
+                    hasError
+                      ? 'border-destructive/50 focus:border-destructive focus:ring-2 focus:ring-destructive/20'
+                      : 'border-border focus:border-primary hover:border-primary/50 focus:ring-2 focus:ring-primary/20'
+                  }`}
+                >
+                  <SelectValue
+                    placeholder={placeholder}
+                    className={`${value ? 'text-slate-800 font-medium' : 'text-muted-foreground'}`}
+                  />
+                </SelectTrigger>
                 <SelectContent className="bg-white/95 backdrop-blur-md border border-border shadow-xl rounded-xl">
-                {options.map((option) => (
-                  <SelectItem 
-                    key={option.value} 
-                    value={option.value}
-                    className="text-sm py-2 px-3 hover:bg-primary/5 hover:text-slate-800 focus:bg-primary/10 focus:text-slate-800 rounded-lg mx-1 transition-colors duration-200"
-                  >
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+                  {options.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      className="text-sm py-2 px-3 hover:bg-primary/5 hover:text-slate-800 focus:bg-primary/10 focus:text-slate-800 rounded-lg mx-1 transition-colors duration-200"
+                    >
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
         </div>
       </div>
     </div>

--- a/src/components/survey/SurveySection1.tsx
+++ b/src/components/survey/SurveySection1.tsx
@@ -58,7 +58,7 @@ export function SurveySection1({ data, onUpdate, errors = [] }: SurveySection1Pr
   };
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-2">
       <SelectQuestion
         questionNumber={1}
         question="Área principal de trabalho:"

--- a/src/components/survey/SurveySection2.tsx
+++ b/src/components/survey/SurveySection2.tsx
@@ -18,7 +18,7 @@ export function SurveySection2({ data, onUpdate, errors = [] }: SurveySection2Pr
   };
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-2">
       <Question
         questionNumber={21}
         question="Meu chefe está interessado em ouvir as minhas ideias."

--- a/src/components/survey/SurveySection3.tsx
+++ b/src/components/survey/SurveySection3.tsx
@@ -18,7 +18,7 @@ export function SurveySection3({ data, onUpdate, errors = [] }: SurveySection3Pr
   };
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-2">
       <Question
         questionNumber={30}
         question="Recebo regularmente informações sobre o meu desempenho."

--- a/src/components/survey/SurveySection4.tsx
+++ b/src/components/survey/SurveySection4.tsx
@@ -37,49 +37,49 @@ export function SurveySection4({ data, onUpdate, errors = [] }: SurveySection4Pr
   ];
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-2">
       {questions.map((question, index) => {
         const hasError = errors.includes(question.id);
         const questionNumber = index + 1;
-        
+
         return (
-          <div 
+          <div
             key={question.id}
             id={`question-${question.id}`}
-            className={`question-card p-6 mb-4 fade-in ${
+            className={`question-card p-4 mb-3 fade-in ${
               hasError ? 'question-card-error' : ''
             }`}
           >
             {hasError && (
-              <div className="mb-3 p-3 bg-destructive/10 border border-destructive/20 rounded-xl">
+              <div className="mb-2 p-3 bg-destructive/10 border border-destructive/20 rounded-xl">
                 <p className="text-destructive text-sm font-medium flex items-center gap-2">
                   <MessageSquare className="w-4 h-4" />
                   Esta pergunta é obrigatória
                 </p>
               </div>
             )}
-            
-            <div className="flex items-start gap-4 mb-4">
+
+            <div className="flex items-start gap-3 mb-3">
               <div className={`w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0 shadow-sm transition-all duration-300 ${
-                hasError 
-                  ? 'bg-destructive text-white' 
+                hasError
+                  ? 'bg-destructive text-white'
                   : 'bg-gradient-primary text-white'
               }`}>
                 <span className="font-bold text-base">{questionNumber}</span>
               </div>
               <div className="flex-1">
-                <Label className={`text-sm md:text-base font-semibold leading-snug block mb-3 ${
+                <Label className={`text-sm md:text-base font-semibold leading-snug block mb-2 ${
                   hasError ? 'text-destructive' : 'text-slate-800'
                 }`}>
                   {question.question}
                 </Label>
-                
+
                 <div className="relative">
                   <Textarea
                     value={data[question.id] || ''}
                     onChange={(e) => handleChange(question.id, e.target.value)}
                     placeholder={question.placeholder}
-                    className={`min-h-[120px] text-base resize-none transition-all duration-200 ${
+                    className={`min-h-[110px] text-base resize-none transition-all duration-200 ${
                       hasError 
                         ? 'border-destructive focus:border-destructive' 
                         : 'border-slate-300 focus:border-primary'

--- a/src/index.css
+++ b/src/index.css
@@ -160,9 +160,10 @@
 
   /* Question Cards - Following PAPEM Style Guide */
   .question-card {
-    @apply bg-gradient-to-br from-white/80 to-white/60 border border-slate-200/70 backdrop-blur-sm;
-    @apply rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl;
+    @apply bg-white border border-slate-200/70 rounded-xl shadow-sm transition-all duration-200;
+    @apply hover:shadow-md hover:border-primary/25;
     @apply animate-fade-in;
+    backdrop-filter: blur(6px);
   }
 
   .question-card-error {
@@ -226,27 +227,27 @@
 
   /* Advanced UI Classes */
   .question-card-enhanced {
-    @apply relative bg-white rounded-2xl border border-slate-200 shadow-sm;
-    @apply hover:shadow-md hover:border-primary/20 transition-all duration-300;
-    @apply focus-within:shadow-lg focus-within:border-primary/40;
-    background: linear-gradient(145deg, rgba(255,255,255,0.95) 0%, rgba(248,250,252,0.95) 100%);
+    @apply relative bg-white rounded-xl border border-slate-200/80 shadow-sm;
+    @apply hover:shadow-md hover:border-primary/25 transition-all duration-200;
+    @apply focus-within:shadow-md focus-within:border-primary/40;
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 250, 252, 0.9) 100%);
   }
 
   .option-button-enhanced {
-    @apply relative rounded-xl border-2 font-medium transition-all duration-200;
+    @apply relative rounded-xl border font-medium transition-all duration-200 px-4 py-3 text-sm sm:text-base;
     @apply hover:scale-[1.02] active:scale-[0.98];
     @apply focus:outline-none focus:ring-2 focus:ring-primary/30 focus:ring-offset-2;
     transform-origin: center;
   }
 
   .option-button-selected-enhanced {
-    @apply bg-gradient-to-r from-primary to-primary-hover text-white border-primary;
-    @apply shadow-lg shadow-primary/25 hover:shadow-xl hover:shadow-primary/30;
-    @apply scale-[1.02];
+    @apply bg-gradient-to-r from-primary to-primary-hover text-white border-2 border-primary;
+    @apply shadow-md shadow-primary/20 hover:shadow-lg hover:shadow-primary/25;
+    @apply scale-[1.01];
   }
 
   .option-button-unselected-enhanced {
-    @apply bg-white border-slate-200 text-slate-700;
+    @apply bg-white border-slate-200/80 text-slate-700;
     @apply hover:bg-slate-50 hover:border-slate-300 hover:text-slate-800;
     @apply hover:shadow-sm;
   }


### PR DESCRIPTION
## Summary
- tighten the spacing between question blocks across the survey sections to create a more compact flow
- lighten the question card styles and reduce padding/gaps for both multiple choice and free-text cards
- tweak option button sizing and select controls so responses sit closer together while remaining accessible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e516fcd4448321be4ec63d137b1265