### PR TITLE
Atualiza escala de respostas Likert

### DIFF
--- a/README_BANCO_DADOS.md
+++ b/README_BANCO_DADOS.md
@@ -132,11 +132,10 @@ Armazena todas as respostas da pesquisa de clima organizacional.
 
 Todas as questões de escala Likert utilizam os seguintes valores:
 
-- **"Concordo Totalmente"**
+- **"Concordo totalmente"**
 - **"Concordo"**
-- **"Neutro"**
 - **"Discordo"**
-- **"Discordo Totalmente"**
+- **"Discordo totalmente"**
 
 ---
 

--- a/setup-database.sh
+++ b/setup-database.sh
@@ -102,13 +102,13 @@ INSERT INTO survey_responses (
     reconhecimento_trabalho, satisfacao_geral,
     comentarios_gerais, ip_address
 ) VALUES (
-    'SECRETARIA', 'Concordo', 'Concordo', 'Concordo',
-    'Concordo', 'Concordo', 'Concordo',
-    'Distrito', 'Concordo', 'Concordo',
+    'SECRETARIA', 'Concordo totalmente', 'Concordo', 'Concordo totalmente',
+    'Concordo totalmente', 'Concordo', 'Concordo totalmente',
+    'Distrito', 'Concordo', 'Concordo totalmente',
     'Oficiais', 'Discordo', 'Concordo',
-    'Concordo', 'Concordo', 'Concordo',
-    'Concordo', 'Concordo', 'Concordo', 'Concordo',
-    'Concordo', 'Concordo',
+    'Concordo', 'Concordo totalmente', 'Concordo',
+    'Concordo', 'Concordo', 'Concordo totalmente', 'Concordo',
+    'Concordo', 'Concordo totalmente',
     'Resposta de teste inserida automaticamente pelo script de setup.', '127.0.0.1'
 );
 

--- a/src/components/admin/EnvironmentCharts.tsx
+++ b/src/components/admin/EnvironmentCharts.tsx
@@ -54,10 +54,25 @@ const categoricalColors = [
 ];
 
 const mapRatingToCategory = (rating: string) => {
-  const numeric = ratingToNumber(rating);
-  if (numeric >= 4) return "concordo";
-  if (numeric === 3) return "neutro";
-  return "discordo";
+  switch (rating) {
+    case "Concordo totalmente":
+    case "Muito Satisfeito":
+      return "concordoTotalmente" as const;
+    case "Concordo":
+    case "Satisfeito":
+      return "concordo" as const;
+    case "Discordo totalmente":
+    case "Muito Insatisfeito":
+      return "discordoTotalmente" as const;
+    case "Discordo":
+    case "Insatisfeito":
+      return "discordo" as const;
+    case "Não concordo e nem discordo":
+    case "Neutro":
+      return "neutro" as const;
+    default:
+      return ratingToNumber(rating) >= 4 ? "concordo" : "discordo";
+  }
 };
 
 export function EnvironmentCharts() {
@@ -229,17 +244,61 @@ export function EnvironmentCharts() {
           }
 
           const percentages = ratingToPercentage(stats?.ratings ?? []);
-          const counts = { concordo: 0, neutro: 0, discordo: 0 };
+          const counts = {
+            concordoTotalmente: 0,
+            concordo: 0,
+            discordo: 0,
+            discordoTotalmente: 0,
+            neutro: 0,
+          };
           stats?.ratings.forEach((entry) => {
             const category = mapRatingToCategory(entry.rating);
-            counts[category as keyof typeof counts] += entry.count;
+            if (category in counts) {
+              counts[category as keyof typeof counts] += entry.count;
+            }
           });
 
           const chartData = [
-            { category: "Concordo", percentage: percentages.concordo, count: counts.concordo, fill: "hsl(var(--success))" },
-            { category: "Neutro", percentage: percentages.neutro, count: counts.neutro, fill: "hsl(var(--warning))" },
-            { category: "Discordo", percentage: percentages.discordo, count: counts.discordo, fill: "hsl(var(--destructive))" },
+            {
+              category: "Concordo totalmente",
+              key: "concordoTotalmente" as const,
+              percentage: percentages.concordoTotalmente,
+              count: counts.concordoTotalmente,
+              fill: "hsl(var(--success))",
+            },
+            {
+              category: "Concordo",
+              key: "concordo" as const,
+              percentage: percentages.concordo,
+              count: counts.concordo,
+              fill: "#4ade80",
+            },
+            {
+              category: "Discordo",
+              key: "discordo" as const,
+              percentage: percentages.discordo,
+              count: counts.discordo,
+              fill: "#f97316",
+            },
+            {
+              category: "Discordo totalmente",
+              key: "discordoTotalmente" as const,
+              percentage: percentages.discordoTotalmente,
+              count: counts.discordoTotalmente,
+              fill: "hsl(var(--destructive))",
+            },
           ];
+
+          const neutroPercentage = 'neutro' in percentages ? percentages.neutro : undefined;
+          if (typeof neutroPercentage === "number" && counts.neutro > 0) {
+            chartData.splice(2, 0, {
+              category: "Neutro (legado)",
+              key: "neutro" as const,
+              percentage: neutroPercentage,
+              count: counts.neutro,
+              fill: "#94a3b8",
+            });
+          }
 
           const averageScore = stats?.average ? Math.round(stats.average * 20) : null;
 

--- a/src/components/admin/MotivationCharts.tsx
+++ b/src/components/admin/MotivationCharts.tsx
@@ -19,10 +19,25 @@ const sectorOptions = [
 ];
 
 const mapRatingToCategory = (rating: string) => {
-  const numeric = ratingToNumber(rating);
-  if (numeric >= 4) return "concordo";
-  if (numeric === 3) return "neutro";
-  return "discordo";
+  switch (rating) {
+    case "Concordo totalmente":
+    case "Muito Satisfeito":
+      return "concordoTotalmente" as const;
+    case "Concordo":
+    case "Satisfeito":
+      return "concordo" as const;
+    case "Discordo totalmente":
+    case "Muito Insatisfeito":
+      return "discordoTotalmente" as const;
+    case "Discordo":
+    case "Insatisfeito":
+      return "discordo" as const;
+    case "Não concordo e nem discordo":
+    case "Neutro":
+      return "neutro" as const;
+    default:
+      return ratingToNumber(rating) >= 4 ? "concordo" : "discordo";
+  }
 };
 
 export function MotivationCharts() {
@@ -84,17 +99,61 @@ export function MotivationCharts() {
           }
 
           const percentages = ratingToPercentage(stats?.ratings ?? []);
-          const counts = { concordo: 0, neutro: 0, discordo: 0 };
+          const counts = {
+            concordoTotalmente: 0,
+            concordo: 0,
+            discordo: 0,
+            discordoTotalmente: 0,
+            neutro: 0,
+          };
           stats?.ratings.forEach((entry) => {
             const category = mapRatingToCategory(entry.rating);
-            counts[category as keyof typeof counts] += entry.count;
+            if (category in counts) {
+              counts[category as keyof typeof counts] += entry.count;
+            }
           });
 
           const chartData = [
-            { category: "Concordo", percentage: percentages.concordo, count: counts.concordo, fill: "hsl(var(--success))" },
-            { category: "Neutro", percentage: percentages.neutro, count: counts.neutro, fill: "hsl(var(--warning))" },
-            { category: "Discordo", percentage: percentages.discordo, count: counts.discordo, fill: "hsl(var(--destructive))" },
+            {
+              category: "Concordo totalmente",
+              key: "concordoTotalmente" as const,
+              percentage: percentages.concordoTotalmente,
+              count: counts.concordoTotalmente,
+              fill: "hsl(var(--success))",
+            },
+            {
+              category: "Concordo",
+              key: "concordo" as const,
+              percentage: percentages.concordo,
+              count: counts.concordo,
+              fill: "#4ade80",
+            },
+            {
+              category: "Discordo",
+              key: "discordo" as const,
+              percentage: percentages.discordo,
+              count: counts.discordo,
+              fill: "#f97316",
+            },
+            {
+              category: "Discordo totalmente",
+              key: "discordoTotalmente" as const,
+              percentage: percentages.discordoTotalmente,
+              count: counts.discordoTotalmente,
+              fill: "hsl(var(--destructive))",
+            },
           ];
+
+          const neutroPercentage = 'neutro' in percentages ? percentages.neutro : undefined;
+          if (typeof neutroPercentage === "number" && counts.neutro > 0) {
+            chartData.splice(2, 0, {
+              category: "Neutro (legado)",
+              key: "neutro" as const,
+              percentage: neutroPercentage,
+              count: counts.neutro,
+              fill: "#94a3b8",
+            });
+          }
 
           const averageScore = stats?.average ? Math.round(stats.average * 20) : null;
 

--- a/src/components/admin/RealTimeStats.tsx
+++ b/src/components/admin/RealTimeStats.tsx
@@ -81,6 +81,10 @@ export function RealTimeStats() {
     }
   ];
 
+  const hasLegacyNeutral = satisfactionData.some(
+    (item) => 'neutro' in item && typeof item.neutro === 'number' && item.neutro > 0
+  );
+
   return (
     <div className="space-y-6 p-6">
       {/* Header with refresh */}
@@ -236,9 +240,13 @@ export function RealTimeStats() {
                   />
                   <YAxis />
                   <Tooltip formatter={(value) => [`${value}%`, '']} />
+                  <Bar dataKey="concordoTotalmente" stackId="a" fill="#15803d" name="Concordo totalmente" />
                   <Bar dataKey="concordo" stackId="a" fill="#22c55e" name="Concordo" />
-                  <Bar dataKey="neutro" stackId="a" fill="#eab308" name="Neutro" />
-                  <Bar dataKey="discordo" stackId="a" fill="#ef4444" name="Discordo" />
+                  <Bar dataKey="discordo" stackId="a" fill="#f97316" name="Discordo" />
+                  <Bar dataKey="discordoTotalmente" stackId="a" fill="#ef4444" name="Discordo totalmente" />
+                  {hasLegacyNeutral && (
+                    <Bar dataKey="neutro" stackId="a" fill="#94a3b8" name="Neutro (legado)" />
+                  )}
                 </BarChart>
               </ResponsiveContainer>
             </CardContent>

--- a/src/components/admin/RelationshipCharts.tsx
+++ b/src/components/admin/RelationshipCharts.tsx
@@ -19,10 +19,25 @@ const sectorOptions = [
 ];
 
 const mapRatingToCategory = (rating: string) => {
-  const numeric = ratingToNumber(rating);
-  if (numeric >= 4) return "concordo";
-  if (numeric === 3) return "neutro";
-  return "discordo";
+  switch (rating) {
+    case "Concordo totalmente":
+    case "Muito Satisfeito":
+      return "concordoTotalmente" as const;
+    case "Concordo":
+    case "Satisfeito":
+      return "concordo" as const;
+    case "Discordo totalmente":
+    case "Muito Insatisfeito":
+      return "discordoTotalmente" as const;
+    case "Discordo":
+    case "Insatisfeito":
+      return "discordo" as const;
+    case "Não concordo e nem discordo":
+    case "Neutro":
+      return "neutro" as const;
+    default:
+      return ratingToNumber(rating) >= 4 ? "concordo" : "discordo";
+  }
 };
 
 export function RelationshipCharts() {
@@ -84,17 +99,61 @@ export function RelationshipCharts() {
           }
 
           const percentages = ratingToPercentage(stats?.ratings ?? []);
-          const counts = { concordo: 0, neutro: 0, discordo: 0 };
+          const counts = {
+            concordoTotalmente: 0,
+            concordo: 0,
+            discordo: 0,
+            discordoTotalmente: 0,
+            neutro: 0,
+          };
           stats?.ratings.forEach((entry) => {
             const category = mapRatingToCategory(entry.rating);
-            counts[category as keyof typeof counts] += entry.count;
+            if (category in counts) {
+              counts[category as keyof typeof counts] += entry.count;
+            }
           });
 
           const chartData = [
-            { category: "Concordo", percentage: percentages.concordo, count: counts.concordo, fill: "hsl(var(--success))" },
-            { category: "Neutro", percentage: percentages.neutro, count: counts.neutro, fill: "hsl(var(--warning))" },
-            { category: "Discordo", percentage: percentages.discordo, count: counts.discordo, fill: "hsl(var(--destructive))" },
+            {
+              category: "Concordo totalmente",
+              key: "concordoTotalmente" as const,
+              percentage: percentages.concordoTotalmente,
+              count: counts.concordoTotalmente,
+              fill: "hsl(var(--success))",
+            },
+            {
+              category: "Concordo",
+              key: "concordo" as const,
+              percentage: percentages.concordo,
+              count: counts.concordo,
+              fill: "#4ade80",
+            },
+            {
+              category: "Discordo",
+              key: "discordo" as const,
+              percentage: percentages.discordo,
+              count: counts.discordo,
+              fill: "#f97316",
+            },
+            {
+              category: "Discordo totalmente",
+              key: "discordoTotalmente" as const,
+              percentage: percentages.discordoTotalmente,
+              count: counts.discordoTotalmente,
+              fill: "hsl(var(--destructive))",
+            },
           ];
+
+          const neutroPercentage = 'neutro' in percentages ? percentages.neutro : undefined;
+          if (typeof neutroPercentage === "number" && counts.neutro > 0) {
+            chartData.splice(2, 0, {
+              category: "Neutro (legado)",
+              key: "neutro" as const,
+              percentage: neutroPercentage,
+              count: counts.neutro,
+              fill: "#94a3b8",
+            });
+          }
 
           const averageScore = stats?.average ? Math.round(stats.average * 20) : null;
 

--- a/src/components/survey/Question.tsx
+++ b/src/components/survey/Question.tsx
@@ -51,7 +51,7 @@ export function Question({ question, name, value, onChange, options, required = 
       </div>
 
       <div className="flex justify-center">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 w-full max-w-4xl">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 w-full max-w-4xl">
           {options.map((option, index) => {
             const isSelected = value === option.value;
 

--- a/src/components/survey/SurveySection1.tsx
+++ b/src/components/survey/SurveySection1.tsx
@@ -8,9 +8,10 @@ interface SurveySection1Props {
 }
 
 const likertOptions = [
+  { value: "Concordo totalmente", label: "Concordo totalmente" },
+  { value: "Concordo", label: "Concordo" },
   { value: "Discordo", label: "Discordo" },
-  { value: "Não concordo e nem discordo", label: "Não concordo e nem discordo" },
-  { value: "Concordo", label: "Concordo" }
+  { value: "Discordo totalmente", label: "Discordo totalmente" }
 ];
 
 const setorOptions = [

--- a/src/components/survey/SurveySection2.tsx
+++ b/src/components/survey/SurveySection2.tsx
@@ -7,9 +7,10 @@ interface SurveySection2Props {
 }
 
 const likertOptions = [
+  { value: "Concordo totalmente", label: "Concordo totalmente" },
+  { value: "Concordo", label: "Concordo" },
   { value: "Discordo", label: "Discordo" },
-  { value: "Não concordo e nem discordo", label: "Não concordo e nem discordo" },
-  { value: "Concordo", label: "Concordo" }
+  { value: "Discordo totalmente", label: "Discordo totalmente" }
 ];
 
 export function SurveySection2({ data, onUpdate, errors = [] }: SurveySection2Props) {

--- a/src/components/survey/SurveySection3.tsx
+++ b/src/components/survey/SurveySection3.tsx
@@ -7,9 +7,10 @@ interface SurveySection3Props {
 }
 
 const likertOptions = [
+  { value: "Concordo totalmente", label: "Concordo totalmente" },
+  { value: "Concordo", label: "Concordo" },
   { value: "Discordo", label: "Discordo" },
-  { value: "Não concordo e nem discordo", label: "Não concordo e nem discordo" },
-  { value: "Concordo", label: "Concordo" }
+  { value: "Discordo totalmente", label: "Discordo totalmente" }
 ];
 
 export function SurveySection3({ data, onUpdate, errors = [] }: SurveySection3Props) {


### PR DESCRIPTION
## Summary
- Atualiza todas as seções do questionário para oferecer a escala de quatro opções ("Concordo totalmente" a "Discordo totalmente") e ajusta o layout dos botões
- Revisa os cálculos de distribuição e os gráficos administrativos para considerar as novas categorias, preservando a visibilidade de respostas neutras legadas
- Documenta a nova escala Likert e sincroniza os dados de teste do script de setup com os novos valores

## Testing
- npm run lint *(falha: Cannot find package '@eslint/js/index.js' a partir do eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e6872dab188321b699c8805123bcab